### PR TITLE
Adding Accounts Role Account Viewer Test

### DIFF
--- a/src/main/java/com/orasi/bluesource/Accounts.java
+++ b/src/main/java/com/orasi/bluesource/Accounts.java
@@ -6,9 +6,13 @@ import java.util.List;
 import javax.lang.model.util.Elements;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 import com.orasi.utils.Randomness;
 import com.orasi.utils.TestReporter;
@@ -39,7 +43,7 @@ public class Accounts {
 	@FindBy(xpath = "//select[@id='account_industry_id']") private Listbox lstIndustry;
 	@FindBy(xpath = "//input[@value='Create Account']") private Button btnCreateAccount;
 	@FindBy(xpath = "//*[@id=\"accordion\"]/div/div[5]/div/button[2]") private Button btnEditAccount;
-	
+
 	/**Constructor**/
 	public Accounts(OrasiDriver driver){
 		this.driver = driver;
@@ -258,42 +262,40 @@ public class Accounts {
 		
 		//clickAccountLink(strAccountName);
 		
-		
-		
 		return strAccountName;
 		
 	}
 	
 	/**
-	 * This method checks if the add account button is displayed.
-	 * @return boolean
+	 * Checks if the add account button is visible.
+	 * 
+	 * @return <code>true</code> if the add account button is visible, 
+	 * 		   <code>false</code> otherwise.
 	 * @author Darryl Papke
 	 */
 	public boolean verifyAddButtonIsVisible() {
-		try {
-			btnAddAccount.isDisplayed();
-			return true;
-		}
-		catch (NoSuchElementException e) {
-			return false;	
-		}
-	
+		return btnAddAccount.syncVisible(3, false);
 	}
 	
 	/**
-	 * This method checks if the edit account button is displayed.
-	 * @return boolean
+	 * Checks if the edit account button is visible.
+	 * 
+	 * @return <code>true</code> if the edit account button is visible, 
+	 * 		   <code>false</code> otherwise.
 	 * @author Darryl Papke
 	 */
 	public boolean verifyEditButtonIsVisible() {
-		try {
-			btnEditAccount.isDisplayed();
-			return true;
-		}
-		catch (NoSuchElementException e) {
-			return false;	
-		}
-
+		return btnEditAccount.syncVisible(3, false);
+	}
+	
+	/**
+	 * Clicks the first account link in the accounts table.
+	 * 
+	 * @author Darryl Papke
+	 */
+	public void clickFirstAccountLink() {
+		tblAccounts.getCell(2, 1).findElement(By.cssSelector("a[class='ng-binding']")).click();
 	}
 	
 }
+

--- a/src/main/java/com/orasi/bluesource/Accounts.java
+++ b/src/main/java/com/orasi/bluesource/Accounts.java
@@ -38,6 +38,7 @@ public class Accounts {
 	@FindBy(xpath = "//input[@id='account_name']") private Textbox txtAccountName;
 	@FindBy(xpath = "//select[@id='account_industry_id']") private Listbox lstIndustry;
 	@FindBy(xpath = "//input[@value='Create Account']") private Button btnCreateAccount;
+	@FindBy(xpath = "//*[@id=\"accordion\"]/div/div[5]/div/button[2]") private Button btnEditAccount;
 	
 	/**Constructor**/
 	public Accounts(OrasiDriver driver){
@@ -261,6 +262,38 @@ public class Accounts {
 		
 		return strAccountName;
 		
+	}
+	
+	/**
+	 * This method checks if the add account button is displayed.
+	 * @return boolean
+	 * @author Darryl Papke
+	 */
+	public boolean verifyAddButtonIsVisible() {
+		try {
+			btnAddAccount.isDisplayed();
+			return true;
+		}
+		catch (NoSuchElementException e) {
+			return false;	
+		}
+	
+	}
+	
+	/**
+	 * This method checks if the edit account button is displayed.
+	 * @return boolean
+	 * @author Darryl Papke
+	 */
+	public boolean verifyEditButtonIsVisible() {
+		try {
+			btnEditAccount.isDisplayed();
+			return true;
+		}
+		catch (NoSuchElementException e) {
+			return false;	
+		}
+
 	}
 	
 }

--- a/src/main/java/com/orasi/bluesource/Employees.java
+++ b/src/main/java/com/orasi/bluesource/Employees.java
@@ -3,17 +3,21 @@ package com.orasi.bluesource;
 import java.util.ResourceBundle;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.Select;
 
 import com.orasi.utils.Constants;
 import com.orasi.utils.Sleeper;
 import com.orasi.utils.TestReporter;
 import com.orasi.web.OrasiDriver;
 import com.orasi.web.webelements.Button;
+import com.orasi.web.webelements.Element;
 import com.orasi.web.webelements.Label;
 import com.orasi.web.webelements.Link;
 import com.orasi.web.webelements.Textbox;
 import com.orasi.web.webelements.Webtable;
+
 import com.orasi.web.webelements.impl.internal.ElementFactory;
 
 public class Employees {
@@ -30,7 +34,9 @@ public class Employees {
 	@FindBy(tagName = "p") private Label lblAmountInTable;
 	@FindBy(xpath = "//*[@id='accordion']/div/div[3]/h4/a") private Button btnManage;
 	@FindBy(xpath = "//div//input[@id='search-bar']") private Textbox txtEmployeeSearch;
-		
+	@FindBy(xpath = "//*[@id=\"employee_account_permission\"]") private Element elePermission;
+	@FindBy(xpath = "/html/body/header/div/nav/ul/li[10]/a") private Button btnLogout;
+	
 	/**Constructor**/
 	public Employees(OrasiDriver driver){
 		this.driver = driver;
@@ -267,6 +273,33 @@ public class Employees {
 		lnkEmployee.focus();
 		boolean blnFoundEmployee = lnkEmployee.isDisplayed();
 		return blnFoundEmployee;
+		
+	}
+	
+	/**
+	 * Checks that a given option is selectable in the Account Permission drop down
+	 * in the add employee page.
+	 * @param option
+	 * @author Darryl Papke
+	 */
+	public boolean checkAccountPermissionOption(String option) {
+		Select accountPermission = new Select(elePermission);
+		try{
+			accountPermission.selectByVisibleText(option);
+			return true;
+		}
+		catch (NoSuchElementException e){
+			return false;
+		}
+			
+	}
+	
+	/**
+	 * This method will logout the current user.
+	 * @author Darryl Papke
+	 */
+	public void clickLogout() {
+		btnLogout.click();
 		
 	}
 	

--- a/src/main/java/com/orasi/bluesource/Employees.java
+++ b/src/main/java/com/orasi/bluesource/Employees.java
@@ -3,18 +3,21 @@ package com.orasi.bluesource;
 import java.util.ResourceBundle;
 
 import org.openqa.selenium.By;
-import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.ui.Select;
 
 import com.orasi.utils.Constants;
 import com.orasi.utils.Sleeper;
 import com.orasi.utils.TestReporter;
+import com.orasi.utils.dataHelpers.personFactory.Person;
 import com.orasi.web.OrasiDriver;
+import com.orasi.web.PageLoaded;
+import com.orasi.web.exceptions.OptionNotInListboxException;
 import com.orasi.web.webelements.Button;
 import com.orasi.web.webelements.Element;
 import com.orasi.web.webelements.Label;
 import com.orasi.web.webelements.Link;
+import com.orasi.web.webelements.Listbox;
 import com.orasi.web.webelements.Textbox;
 import com.orasi.web.webelements.Webtable;
 
@@ -34,8 +37,7 @@ public class Employees {
 	@FindBy(tagName = "p") private Label lblAmountInTable;
 	@FindBy(xpath = "//*[@id='accordion']/div/div[3]/h4/a") private Button btnManage;
 	@FindBy(xpath = "//div//input[@id='search-bar']") private Textbox txtEmployeeSearch;
-	@FindBy(xpath = "//*[@id=\"employee_account_permission\"]") private Element elePermission;
-	@FindBy(xpath = "/html/body/header/div/nav/ul/li[10]/a") private Button btnLogout;
+	@FindBy(xpath = "//*[@id=\"employee_account_permission\"]") private Listbox lstAccountPermission;
 	
 	/**Constructor**/
 	public Employees(OrasiDriver driver){
@@ -68,6 +70,20 @@ public class Employees {
 		
 		//complete text fields
 		completeRequiredFields(username,firstname,lastname);
+		
+		//click Create Employee
+		clickCreateEmployee();
+	}
+	
+	/**
+	 * Use the Person class to complete the employee modal
+	 * to add a new employee. 
+	 * @param person
+	 */
+	public void addEmployeeModal(Person person) {
+		
+		//complete text fields
+		completeRequiredFields(person.getUsername(),person.getFirstName(), person.getLastName());
 		
 		//click Create Employee
 		clickCreateEmployee();
@@ -181,8 +197,8 @@ public class Employees {
 		String message = "On the employee information page.";
 		String failMessage = "Button 'Manage' is not found\n";
 				
-		tblEmployees.clickCell(row, column);
-		
+		//tblEmployees.clickCell(row, column);
+		tblEmployees.getCell(2, 1).findElement(By.cssSelector("a[class='ng-binding']")).click();
 		if(btnManage.isDisplayed() == true)
 		{
 			TestReporter.assertTrue(btnManage.isDisplayed(), message);
@@ -278,29 +294,22 @@ public class Employees {
 	
 	/**
 	 * Checks that a given option is selectable in the Account Permission drop down
-	 * in the add employee page.
-	 * @param option
-	 * @author Darryl Papke
+	 * in the add employee modal and selects it if possible.
+	 * 
+	 * @param strOption - the Account Permission role you would like to check for.
+	 * @return			<code>true</code> if the account permission option provided
+	 * 					by the user is available, <code>false</code> otherwise.
+	 * @author			Darryl Papke
 	 */
-	public boolean checkAccountPermissionOption(String option) {
-		Select accountPermission = new Select(elePermission);
+	public boolean checkAccountPermissionOption(String strOption) {
 		try{
-			accountPermission.selectByVisibleText(option);
+			lstAccountPermission.select(strOption);
 			return true;
 		}
-		catch (NoSuchElementException e){
+		catch (OptionNotInListboxException e){
 			return false;
 		}
 			
 	}
-	
-	/**
-	 * This method will logout the current user.
-	 * @author Darryl Papke
-	 */
-	public void clickLogout() {
-		btnLogout.click();
-		
-	}
-	
+
 }

--- a/src/main/java/com/orasi/bluesource/Header.java
+++ b/src/main/java/com/orasi/bluesource/Header.java
@@ -14,6 +14,7 @@ public class Header {
 	
 	/**Page Elements**/
 	@FindBy(linkText = "Accounts") private Link lnkAccounts;
+	@FindBy(linkText = "Logout") private Link lnkLogout;
 	@FindBy(xpath = "//li[contains(.,'Employees')]/a") private Link lnkEmployees;
 	@FindBy(xpath = "//a[contains(text(),'Project')]") private Link lnkProjemployees;
 	@FindBy(xpath = "//a[contains(text(),'Project')]//..//..//..//following-sibling::a") private Link lnkEmployeeSelector;
@@ -72,6 +73,12 @@ public class Header {
 		lnkEmployeeSelector.click();
 		lnkProjemployees.click();
 		
+	}
+	
+	public void navigateLogout() {
+		MessageCenter messageCenter = new MessageCenter(driver);
+		messageCenter.closeMessageCenter();
+		lnkLogout.click();		
 	}
 
 }

--- a/src/test/java/com/bluesource/accounts/AccountViewerRole.java
+++ b/src/test/java/com/bluesource/accounts/AccountViewerRole.java
@@ -1,0 +1,77 @@
+package com.bluesource.accounts;
+
+import org.testng.ITestContext;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import com.orasi.bluesource.Accounts;
+import com.orasi.bluesource.Employees;
+import com.orasi.bluesource.Header;
+import com.orasi.bluesource.LoginPage;
+import com.orasi.utils.TestReporter;
+import com.orasi.web.PageLoaded;
+import com.orasi.web.WebBaseTest;
+
+public class AccountViewerRole extends WebBaseTest {
+	
+	// ************* *
+	// Data Provider
+	// **************
+	/*@DataProvider(name = "accounts_industry", parallel=true)
+	public Object[][] scenarios() {
+			return new ExcelDataProvider("/testdata/blueSource_Users.xlsx", "Sheet1").getTestData();
+	}*/
+	
+	@BeforeMethod
+    @Parameters({ "runLocation", "browserUnderTest", "browserVersion",
+    	"operatingSystem", "environment" })
+    public void setup(@Optional String runLocation, String browserUnderTest,
+	    String browserVersion, String operatingSystem, String environment) {
+    	setApplicationUnderTest("BLUESOURCE");
+		setBrowserUnderTest(browserUnderTest);
+		setBrowserVersion(browserVersion);
+		setOperatingSystem(operatingSystem);
+		setRunLocation(runLocation);
+		setEnvironment(environment);
+		setThreadDriver(true);
+		testStart("");
+	}
+    
+    @AfterMethod
+    public void close(ITestContext testResults){
+    	endTest("TestAlert", testResults);
+    }
+    
+    @Test(groups = {"smoke"} )
+    public void accountViewerRole() {
+    	LoginPage loginPage = new LoginPage(getDriver());
+    	Header header = new Header(getDriver());
+    	Employees employees = new Employees(getDriver());
+    	Accounts accounts = new Accounts(getDriver());
+
+    	loginPage.AdminLogin();
+    	header.navigateEmployees();
+    	PageLoaded.isDomComplete(getDriver(), 5);
+    	employees.clickAddEmployee();
+    	TestReporter.assertTrue(employees.checkAccountPermissionOption("Account Viewer"), "Account Viewer is an option");
+
+    	String first = "Jane";
+    	String last = "Doe";
+    	String user = first + last;
+    	String password = "123";
+    	
+    	employees.addEmployeeModal(user, first, last);
+    	employees.clickLogout();
+    	loginPage.LoginWithCredentials(user, password);
+    	header.navigateAccounts();
+    	TestReporter.assertFalse(accounts.verifyAddButtonIsVisible(), "Add Account button is not present");
+    	
+    	accounts.clickAccountLink("Account1");
+    	TestReporter.assertFalse(accounts.verifyEditButtonIsVisible(), "Edit Account button is not present");
+    	
+    }
+
+}

--- a/src/test/java/com/bluesource/accounts/AccountViewerRole.java
+++ b/src/test/java/com/bluesource/accounts/AccountViewerRole.java
@@ -12,12 +12,12 @@ import com.orasi.bluesource.Employees;
 import com.orasi.bluesource.Header;
 import com.orasi.bluesource.LoginPage;
 import com.orasi.utils.TestReporter;
-import com.orasi.web.PageLoaded;
+import com.orasi.utils.dataHelpers.personFactory.Person;
 import com.orasi.web.WebBaseTest;
 
 public class AccountViewerRole extends WebBaseTest {
 	
-	// ************* *
+	// **************
 	// Data Provider
 	// **************
 	/*@DataProvider(name = "accounts_industry", parallel=true)
@@ -47,30 +47,42 @@ public class AccountViewerRole extends WebBaseTest {
     
     @Test(groups = {"smoke"} )
     public void accountViewerRole() {
-    	LoginPage loginPage = new LoginPage(getDriver());
+    	Person person = new Person();
     	Header header = new Header(getDriver());
-    	Employees employees = new Employees(getDriver());
     	Accounts accounts = new Accounts(getDriver());
-
+    	LoginPage loginPage = new LoginPage(getDriver());
+    	Employees employees = new Employees(getDriver());
+    	
+    	TestReporter.logStep("Test started");
+    	
+    	TestReporter.logStep("Login to application");
     	loginPage.AdminLogin();
+    	
+    	TestReporter.logStep("Go to the Employees page to add a new employee");
     	header.navigateEmployees();
-    	PageLoaded.isDomComplete(getDriver(), 5);
     	employees.clickAddEmployee();
-    	TestReporter.assertTrue(employees.checkAccountPermissionOption("Account Viewer"), "Account Viewer is an option");
+    	
+    	TestReporter.logStep("Test that Account Viewer is an option in the Account Permission dropdown");
+    	TestReporter.assertTrue(employees.checkAccountPermissionOption("Account Viewer"), "Checked that Account Viewer is an option and selects it.");
 
-    	String first = "Jane";
-    	String last = "Doe";
-    	String user = first + last;
-    	String password = "123";
+    	TestReporter.logStep("Add a new employee using the Person class");
+    	employees.addEmployeeModal(person);
+    	header.navigateLogout();
     	
-    	employees.addEmployeeModal(user, first, last);
-    	employees.clickLogout();
-    	loginPage.LoginWithCredentials(user, password);
+    	TestReporter.logStep("Login as the new employee");
+    	loginPage.LoginWithCredentials(person.getUsername(), person.getPassword());
+    	
+    	TestReporter.logStep("Go to the Accounts page");
     	header.navigateAccounts();
-    	TestReporter.assertFalse(accounts.verifyAddButtonIsVisible(), "Add Account button is not present");
     	
-    	accounts.clickAccountLink("Account1");
-    	TestReporter.assertFalse(accounts.verifyEditButtonIsVisible(), "Edit Account button is not present");
+    	TestReporter.logStep("Test that the add account button is not present");
+    	TestReporter.assertFalse(accounts.verifyAddButtonIsVisible(), "Checked that the Add Account button is not present.");
+    	
+    	TestReporter.logStep("Go to an account");
+    	accounts.clickFirstAccountLink();
+    	
+    	TestReporter.logStep("Test that the edit account button is not present");
+    	TestReporter.assertFalse(accounts.verifyEditButtonIsVisible(), "Checked that the Edit Account button is not present.");
     	
     }
 

--- a/src/test/resources/smoke.xml
+++ b/src/test/resources/smoke.xml
@@ -22,6 +22,7 @@
 			<class name="com.bluesource.employees.CreateBasicUser" />
 		</classes>
 	</test>
+	
 	<test name="Create Account" parallel="methods" thread-count="20">
 		<classes>
 			<class name="com.bluesource.accounts.CreateAccount" />


### PR DESCRIPTION
This adds a test for checking that account viewer is an account permission when adding a new employee. The test also checks that an employee with account viewer permission can only view accounts and cannot add or edit accounts. 

With access to (https://mustard.orasi.com) the test case can be found here - https://mustard.orasi.com/testcases/4071.