### PR TITLE
Adding Accounts Account Viewer Quick Nav Issue #667 Test

### DIFF
--- a/src/main/java/com/orasi/bluesource/Accounts.java
+++ b/src/main/java/com/orasi/bluesource/Accounts.java
@@ -43,6 +43,8 @@ public class Accounts {
 	@FindBy(xpath = "//select[@id='account_industry_id']") private Listbox lstIndustry;
 	@FindBy(xpath = "//input[@value='Create Account']") private Button btnCreateAccount;
 	@FindBy(xpath = "//*[@id=\"accordion\"]/div/div[5]/div/button[2]") private Button btnEditAccount;
+	@FindBy(css = "div.btn.btn-secondary.btn-xs.quick-nav") private Button btnQuickNav;
+	@FindBy(xpath = "//a[contains(@ng-bind, 'n + 1')]") private List<Button> btnPages;
 
 	/**Constructor**/
 	public Accounts(OrasiDriver driver){
@@ -270,7 +272,7 @@ public class Accounts {
 	 * Checks if the add account button is visible.
 	 * 
 	 * @return <code>true</code> if the add account button is visible, 
-	 * 		   <code>false</code> otherwise.
+	 * <code>false</code> otherwise.
 	 * @author Darryl Papke
 	 */
 	public boolean verifyAddButtonIsVisible() {
@@ -281,7 +283,7 @@ public class Accounts {
 	 * Checks if the edit account button is visible.
 	 * 
 	 * @return <code>true</code> if the edit account button is visible, 
-	 * 		   <code>false</code> otherwise.
+	 * <code>false</code> otherwise.
 	 * @author Darryl Papke
 	 */
 	public boolean verifyEditButtonIsVisible() {
@@ -297,5 +299,37 @@ public class Accounts {
 		tblAccounts.getCell(2, 1).findElement(By.cssSelector("a[class='ng-binding']")).click();
 	}
 	
+	/**
+	 * Checks if the Quick Nav button is displayed.
+	 * 
+	 * @return <code>true</code> if the Quick Nav button is visible, 
+	 * <code>false</code> otherwise.
+	 * @author Darryl Papke
+	 */
+	public boolean verifyQuickNavButtonIsVisible() {
+		return btnQuickNav.syncVisible(5, true);
+	}
+	
+	/**
+	 * Goes through each page of accounts and checks if the Quick Nav button
+	 * is visible on each page.
+	 * 
+	 * @return <code>true</code> if the Quick Nav button is on each page, 
+	 * <code>false</code> otherwise.
+	 * @author Darryl Papke
+	 */
+	public boolean verifyQuickNavButtonEachPage() {
+		boolean answer = false;
+		for(Button page : btnPages) {
+			page.syncEnabled(5);
+			page.click();
+			answer = verifyQuickNavButtonIsVisible();
+			if(!verifyQuickNavButtonIsVisible()) {
+				return false;
+			}
+		}
+		return answer;
+	}
+
 }
 

--- a/src/main/java/com/orasi/bluesource/Employees.java
+++ b/src/main/java/com/orasi/bluesource/Employees.java
@@ -197,8 +197,8 @@ public class Employees {
 		String message = "On the employee information page.";
 		String failMessage = "Button 'Manage' is not found\n";
 				
-		//tblEmployees.clickCell(row, column);
-		tblEmployees.getCell(2, 1).findElement(By.cssSelector("a[class='ng-binding']")).click();
+		tblEmployees.clickCell(row, column);
+
 		if(btnManage.isDisplayed() == true)
 		{
 			TestReporter.assertTrue(btnManage.isDisplayed(), message);
@@ -296,10 +296,10 @@ public class Employees {
 	 * Checks that a given option is selectable in the Account Permission drop down
 	 * in the add employee modal and selects it if possible.
 	 * 
-	 * @param strOption - the Account Permission role you would like to check for.
-	 * @return			<code>true</code> if the account permission option provided
-	 * 					by the user is available, <code>false</code> otherwise.
-	 * @author			Darryl Papke
+	 * @param strOption the Account Permission role you would like to check for.
+	 * @return <code>true</code> if the account permission option provided
+	 * by the user is available, <code>false</code> otherwise.
+	 * @author Darryl Papke
 	 */
 	public boolean checkAccountPermissionOption(String strOption) {
 		try{

--- a/src/main/resources/UserCredentials.properties
+++ b/src/main/resources/UserCredentials.properties
@@ -1,4 +1,5 @@
 ADMIN=company.admin
 PROJECT_USER=department1.m1e3
+ACCOUNT_VIEWER=test327
 
 PASSWORD=123

--- a/src/test/java/com/bluesource/accounts/AccountViewerQuickNav.java
+++ b/src/test/java/com/bluesource/accounts/AccountViewerQuickNav.java
@@ -1,0 +1,69 @@
+package com.bluesource.accounts;
+
+import org.testng.ITestContext;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import com.orasi.bluesource.Accounts;
+import com.orasi.bluesource.Header;
+import com.orasi.bluesource.LoginPage;
+import com.orasi.utils.TestReporter;
+import com.orasi.web.WebBaseTest;
+
+public class AccountViewerQuickNav extends WebBaseTest {
+
+	// **************
+	// Data Provider
+	// **************
+	/*@DataProvider(name = "accounts_industry", parallel=true)
+	public Object[][] scenarios() {
+		return new ExcelDataProvider("/testdata/blueSource_Users.xlsx", "Sheet1").getTestData();
+	}*/
+	
+	@BeforeMethod
+    @Parameters({ "runLocation", "browserUnderTest", "browserVersion",
+    	"operatingSystem", "environment" })
+    public void setup(@Optional String runLocation, String browserUnderTest,
+	    String browserVersion, String operatingSystem, String environment) {
+    	setApplicationUnderTest("BLUESOURCE");
+		setBrowserUnderTest(browserUnderTest);
+		setBrowserVersion(browserVersion);
+		setOperatingSystem(operatingSystem);
+		setRunLocation(runLocation);
+		setEnvironment(environment);
+		setThreadDriver(true);
+		testStart("");
+	}
+    
+    @AfterMethod
+    public void close(ITestContext testResults){
+    	endTest("TestAlert", testResults);
+    }
+    
+    @Test(groups = {"smoke"} )
+    public void accountViewerQuickNav() {
+    	Header header = new Header(getDriver());
+    	Accounts accounts = new Accounts(getDriver());
+    	LoginPage loginPage = new LoginPage(getDriver());
+    	
+    	TestReporter.logStep("Test started");
+    	
+    	TestReporter.logStep("Login to application as an employee with Account Viewer permission");
+    	loginPage.Login("ACCOUNT_VIEWER");
+    	
+    	TestReporter.logStep("Go to the Accounts page");
+    	header.navigateAccounts();
+    	
+    	TestReporter.assertTrue(accounts.verifyQuickNavButtonEachPage(), "Checked that the Quick Nav button is on each page of accounts");
+    	
+    	TestReporter.logStep("Go to an account page and verify the Quick Nav button is visible");
+    	accounts.clickFirstAccountLink();
+    	
+    	TestReporter.assertTrue(accounts.verifyQuickNavButtonIsVisible(), "Checked that the Quick Nav button is visible on an account page");
+    	
+    }
+    
+}

--- a/src/test/resources/smoke.xml
+++ b/src/test/resources/smoke.xml
@@ -29,4 +29,10 @@
 		</classes>
 	</test>
 	
+	<test name="Account Viewer Role" parallel="methods" thread-count="20">
+		<classes>
+			<class name="com.bluesource.accounts.AccountViewerRole" />
+		</classes>
+	</test>
+	
 </suite> <!-- Suite -->


### PR DESCRIPTION
This adds a test for checking that the Quick Nav button is visible on the Accounts page for an employee with the Account Viewer permission. 

With access to (https://mustard.orasi.com) the test case can be found here - https://mustard.orasi.com/testcases/4541