### PR TITLE
Adding Accounts Quick Nav Close Menu Test

### DIFF
--- a/src/main/java/com/orasi/bluesource/Accounts.java
+++ b/src/main/java/com/orasi/bluesource/Accounts.java
@@ -32,7 +32,7 @@ public class Accounts {
 	
 	/**Page Elements**/
 	@FindBy(xpath = "//*[@id='resource-content']/div[2]/p") private Element elmNumberPages;
-	@FindBy(tagName = "tbody") private Webtable tblAccounts;
+	@FindBy(xpath = "//*[@id=\"resource-content\"]/div[1]/table/tbody") private Webtable tblAccounts;
 	@FindBy(id = "preference_resources_per_page") private Listbox lstAccountPerPage;
 	@FindBy(linkText = "Industry") private Link lnkIndustry;
 	@FindBy(linkText = "Accounts") private Link lnkAccountsTab;
@@ -45,6 +45,7 @@ public class Accounts {
 	@FindBy(xpath = "//*[@id=\"accordion\"]/div/div[5]/div/button[2]") private Button btnEditAccount;
 	@FindBy(css = "div.btn.btn-secondary.btn-xs.quick-nav") private Button btnQuickNav;
 	@FindBy(xpath = "//a[contains(@ng-bind, 'n + 1')]") private List<Button> btnPages;
+	@FindBy(xpath = "//*[@id=\"project-list\"]/div/div[1]/div") private Button btnCloseQuickNav;
 
 	/**Constructor**/
 	public Accounts(OrasiDriver driver){
@@ -330,6 +331,49 @@ public class Accounts {
 			}
 		}
 		return answer;
+	}
+	
+	/**
+	 * Clicks the Quick Nav button.
+	 * 
+	 * @author Darryl Papke
+	 */
+	public void clickQuickNav() {
+		btnQuickNav.click();
+	}
+
+	/**
+	 * Clicks the close quick nav button.
+	 * 
+	 * @author Darryl Papke
+	 */
+	public void closeQuickNav() {
+		PageLoaded.isDomComplete(driver, 5);
+		btnCloseQuickNav.click();
+	}
+	
+	/**
+	 * Checks if the Quick Nav close button is visible.
+	 * 
+	 * @return <code>true</code> if the Quick Nav close button is 
+	 * visible, <code>false</code> otherwise.
+	 * @author Darryl Papke
+	 */
+	public boolean verifyQuickNavCloseButtonIsVisible() {
+		PageLoaded.isDomComplete(driver, 5);
+		return btnCloseQuickNav.syncVisible(3, false);
+	}
+	
+	/**
+	 * Clicks on a cell in the Accounts table from given coordinates.
+	 * 
+	 * @param row Desired row in which to search for a particular cell
+	 * @param column Desired column in which to find the cell
+	 * @author Darryl Papke
+	 */
+	public void selectCell(int row, int column) {
+		tblAccounts.clickCell(row, column);
+		PageLoaded.isDomComplete(driver, 1);
 	}
 	
 }

--- a/src/test/java/com/bluesource/accounts/QuickNavCloseMenu.java
+++ b/src/test/java/com/bluesource/accounts/QuickNavCloseMenu.java
@@ -1,0 +1,77 @@
+package com.bluesource.accounts;
+
+import org.testng.ITestContext;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import com.orasi.bluesource.Accounts;
+import com.orasi.bluesource.Header;
+import com.orasi.bluesource.LoginPage;
+import com.orasi.utils.TestReporter;
+import com.orasi.web.WebBaseTest;
+
+public class QuickNavCloseMenu extends WebBaseTest{
+	
+	// **************
+	// Data Provider
+	// **************
+	/*@DataProvider(name = "accounts_industry", parallel=true)
+	public Object[][] scenarios() {
+			return new ExcelDataProvider("/testdata/blueSource_Users.xlsx", "Sheet1").getTestData();
+	}*/
+	
+	@BeforeMethod
+    @Parameters({ "runLocation", "browserUnderTest", "browserVersion",
+    	"operatingSystem", "environment" })
+    public void setup(@Optional String runLocation, String browserUnderTest,
+	    String browserVersion, String operatingSystem, String environment) {
+    	setApplicationUnderTest("BLUESOURCE");
+		setBrowserUnderTest(browserUnderTest);
+		setBrowserVersion(browserVersion);
+		setOperatingSystem(operatingSystem);
+		setRunLocation(runLocation);
+		setEnvironment(environment);
+		setThreadDriver(true);
+		testStart("");
+	}
+    
+    @AfterMethod
+    public void close(ITestContext testResults){
+    	endTest("TestAlert", testResults);
+    }
+    
+    @Test(groups = {"smoke"} )
+    public void quickNavCloseMenu() {
+    	Header header = new Header(getDriver());
+    	Accounts account = new Accounts(getDriver());
+    	LoginPage loginPage = new LoginPage(getDriver());
+    	
+    	TestReporter.logStep("Test start");
+    	
+    	TestReporter.logStep("Login to application as an admin");
+    	loginPage.AdminLogin();
+    	
+    	TestReporter.logStep("Go to the accounts page");
+    	header.navigateAccounts();
+
+    	TestReporter.logStep("Open the Quick Nav Menu");
+    	account.clickQuickNav();
+    	
+    	TestReporter.logStep("Close the Quick Nav menu with the close button on the menu");
+    	account.closeQuickNav();
+
+    	TestReporter.assertFalse(account.verifyQuickNavCloseButtonIsVisible(), "The Quick Nav menu was closed with the close button.");
+    	
+    	TestReporter.logStep("Reopen the Quick Nav menu");
+    	account.clickQuickNav();
+    	
+    	TestReporter.logStep("Close the Quick Nav menu by clicking somewhere else on the page");
+    	account.selectCell(2, 2);
+    	
+    	TestReporter.assertFalse(account.verifyQuickNavCloseButtonIsVisible(), "The Quick Nav menu was closed by clicking somewhere else on the page");
+
+    }
+}


### PR DESCRIPTION
This adds a test to check that the Quick Nav menu can be closed by either the close button on the Quick Nav menu or clicking somewhere else on the page with the menu open. 

With access to (https://mustard.orasi.com) the test case can be found here - 
https://mustard.orasi.com/testcases/4545