### PR TITLE
Preserve new lines in project notes Test Issue 789

### DIFF
--- a/src/main/java/com/orasi/bluesource/Accounts.java
+++ b/src/main/java/com/orasi/bluesource/Accounts.java
@@ -106,7 +106,7 @@ public class Accounts {
 	}
 
 	/**
-	 * Clicks the Notes button to bring up the create note form
+	 * Clicks the Notes button/icon to bring up the create note form
 	 * @author David Grayson
 	 */
 	public void clickCreateNote(){

--- a/src/main/java/com/orasi/bluesource/Accounts.java
+++ b/src/main/java/com/orasi/bluesource/Accounts.java
@@ -1,30 +1,16 @@
 package com.orasi.bluesource;
 
-import java.lang.reflect.UndeclaredThrowableException;
-import java.util.List;
-
-import javax.lang.model.util.Elements;
-
-import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
-import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
-
 import com.orasi.utils.Randomness;
-import com.orasi.utils.TestReporter;
 import com.orasi.web.OrasiDriver;
 import com.orasi.web.PageLoaded;
-import com.orasi.web.webelements.Button;
-import com.orasi.web.webelements.Element;
-import com.orasi.web.webelements.Link;
-import com.orasi.web.webelements.Listbox;
-import com.orasi.web.webelements.Textbox;
-import com.orasi.web.webelements.Webtable;
+import com.orasi.web.webelements.*;
 import com.orasi.web.webelements.impl.internal.ElementFactory;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.support.FindBy;
+
+import java.lang.reflect.UndeclaredThrowableException;
+import java.util.List;
 
 public class Accounts {
 	private OrasiDriver driver = null;
@@ -46,6 +32,8 @@ public class Accounts {
 	@FindBy(css = "div.btn.btn-secondary.btn-xs.quick-nav") private Button btnQuickNav;
 	@FindBy(xpath = "//a[contains(@ng-bind, 'n + 1')]") private List<Button> btnPages;
 	@FindBy(xpath = "//*[@id=\"project-list\"]/div/div[1]/div") private Button btnCloseQuickNav;
+	@FindBy(xpath = "//button[@class='contents btn btn-link']") private Button btnCreateProjectNote;
+	@FindBy(xpath = "//span[@class='badge badge-notify']") private Element elmNotesBadge;
 
 	/**Constructor**/
 	public Accounts(OrasiDriver driver){
@@ -54,6 +42,32 @@ public class Accounts {
 	}
 	
 	/**Page Interactions**/
+
+	/**
+	 * Checks the notes badge to get the current number of note associated with the project
+	 * @author david.grayson
+	 * @return number of notes associated with the project
+	 */
+	public int getNumberOfNotes(){
+		return Integer.parseInt(elmNotesBadge.getText());
+	}
+
+	/**
+	 * Checks that the badge with the number of notes is displayed
+	 * @author david.grayson
+	 * @return <code>true</code> if notes are associated with project, <code>false</code> if not.
+	 */
+	public boolean verifyNoteCreated(){
+		return elmNotesBadge.isDisplayed();
+	}
+
+	/**
+	 * Clicks the Notes button to bring up the create note form
+	 * @author david.grayson
+	 */
+	public void clickCreateNote(){
+		btnCreateProjectNote.click();
+	}
 
 	/*
 	 * Click on accounts tab 

--- a/src/main/java/com/orasi/bluesource/Accounts.java
+++ b/src/main/java/com/orasi/bluesource/Accounts.java
@@ -34,6 +34,8 @@ public class Accounts {
 	@FindBy(xpath = "//*[@id=\"project-list\"]/div/div[1]/div") private Button btnCloseQuickNav;
 	@FindBy(xpath = "//button[@class='contents btn btn-link']") private Button btnCreateProjectNote;
 	@FindBy(xpath = "//span[@class='badge badge-notify']") private Element elmNotesBadge;
+	@FindBy(xpath = "//h4[@class='panel-title' and contains(text(),'Project Info')]") private Element elmProjectInfoPanelHeader;
+
 
 	/**Constructor**/
 	public Accounts(OrasiDriver driver){
@@ -44,9 +46,51 @@ public class Accounts {
 	/**Page Interactions**/
 
 	/**
+	 * would use the {@link #verifyProjectLink(String)} but it doesn't do what it's name implies
+	 * @author David Grayson
+	 * @param project {@link String} name of Project
+	 * @return {@link Boolean} Returns <code>true</code> if the link is clickable within 5 seconds, <code>false</code> otherwise.
+	 */
+	public boolean verifyProjectLinkValid(String project){
+		return driver.findLink(By.linkText(project)).syncEnabled(5,false) &&
+				driver.findLink(By.linkText(project)).syncVisible(5,false);
+	}
+
+	/**
+	 * @author David Grayson
+	 * @return {@link Boolean} Returns <code>true</code> if the Accounts table is loaded, <code>false</code> otherwise.
+	 */
+	public boolean verifyAccountsPageIsLoaded(){
+		return PageLoaded.isElementLoaded(this.getClass(),driver,tblAccounts,5);
+	}
+
+	/**
+	 * @author David Grayson
+	 * @param strAccount {@link String} name of Projects parent account
+	 * @param strProject {@link String} name of project
+	 * @return {@link Boolean} Returns <code>true</code> if the provided Projects page is loaded, <code>false</code> otherwise.
+	 */
+	public boolean verifyProjectPageIsLoaded(String strAccount, String strProject){
+		return PageLoaded.isElementLoaded(this.getClass(),driver, elmProjectInfoPanelHeader,5)
+				&& driver.findElement(By.xpath("//div[@class='breadcrumbs']")).getText()
+				.equals("Accounts - " + strAccount + " - " + strProject);
+	}
+
+	/**
+	 * @author David Grayson
+	 * @param strAccount {@link String} name of Account
+	 * @return {@link Boolean} Returns <code>true</code> if the provided Accounts page is loaded, <code>false</code> otherwise.
+	 */
+	public boolean verifyAccountPageIsLoaded(String strAccount){
+		String xpath = "//div[@class='breadcrumbs']/a[contains(text(),'" + strAccount + "')]";
+		return PageLoaded.isElementLoaded(this.getClass(),driver,tblProjects,5)
+				&& driver.findLink(By.xpath(xpath)).syncVisible(5,false);
+	}
+
+	/**
 	 * Checks the notes badge to get the current number of note associated with the project
-	 * @author david.grayson
-	 * @return number of notes associated with the project
+	 * @author David Grayson
+	 * @return {@link Integer}Returns the number of notes associated with the project
 	 */
 	public int getNumberOfNotes(){
 		return Integer.parseInt(elmNotesBadge.getText());
@@ -54,8 +98,8 @@ public class Accounts {
 
 	/**
 	 * Checks that the badge with the number of notes is displayed
-	 * @author david.grayson
-	 * @return <code>true</code> if notes are associated with project, <code>false</code> if not.
+	 * @author David Grayson
+	 * @return {@link Boolean} Returns <code>true</code> if notes are associated with project, <code>false</code> if not.
 	 */
 	public boolean verifyNoteCreated(){
 		return elmNotesBadge.isDisplayed();
@@ -63,7 +107,7 @@ public class Accounts {
 
 	/**
 	 * Clicks the Notes button to bring up the create note form
-	 * @author david.grayson
+	 * @author David Grayson
 	 */
 	public void clickCreateNote(){
 		btnCreateProjectNote.click();

--- a/src/main/java/com/orasi/bluesource/ProjectNoteForm.java
+++ b/src/main/java/com/orasi/bluesource/ProjectNoteForm.java
@@ -1,0 +1,56 @@
+package com.orasi.bluesource;
+
+import com.orasi.utils.TestReporter;
+import com.orasi.web.OrasiDriver;
+import com.orasi.web.webelements.Button;
+import com.orasi.web.webelements.Element;
+import com.orasi.web.webelements.Textbox;
+import com.orasi.web.webelements.impl.internal.ElementFactory;
+import org.openqa.selenium.support.FindBy;
+
+/**
+ * Page driver for the Create Notes Form on the project page
+ * @author david.grayson
+ */
+public class ProjectNoteForm {
+	private OrasiDriver driver = null;
+
+	/**Page Elements**/
+	@FindBy(xpath = "//button[contains(text(),'Add Note')]") private Button btnAddNote;
+	@FindBy(xpath = "//div[@class='notes_form']//textarea[@id='note_note_field']") private Textbox txtNoteField;
+	@FindBy(xpath = "//div[@class='notes_form']//input[@value='Create Note']") private Element elmCreateNote;
+	@FindBy(xpath = "//li/div[@class='note-text']") private Element elmNoteText;
+
+	/**Constructor**/
+	public ProjectNoteForm(OrasiDriver driver) {
+		this.driver = driver;
+		ElementFactory.initElements(driver,this);
+	}
+
+	/**Page Interactions**/
+
+	public void clickAddNote(){
+		btnAddNote.syncEnabled(3);
+		btnAddNote.click();
+	}
+
+	public void setNoteText(String strNote){
+		txtNoteField.syncEnabled(3);
+		txtNoteField.clear();
+		txtNoteField.set(strNote);
+	}
+
+	public void clickCreateNote(){
+		elmCreateNote.click();
+	}
+
+	public String getNoteText(){
+		elmNoteText.syncVisible(3);
+		TestReporter.log("Note Text = [" + elmNoteText.getText() + "]");
+		return elmNoteText.getText();
+	}
+
+	public void testSetNote(){
+		setNoteText("test\ntest test");
+	}
+}

--- a/src/main/java/com/orasi/bluesource/ProjectNoteForm.java
+++ b/src/main/java/com/orasi/bluesource/ProjectNoteForm.java
@@ -30,31 +30,47 @@ public class ProjectNoteForm {
 
 	/**Page Interactions**/
 
+	/**
+	 * Clicks the add note button
+	 * @author David Grayson
+	 */
 	public void clickAddNote(){
 		btnAddNote.syncEnabled(3);
 		btnAddNote.click();
 	}
 
+	/**
+	 * sets the Note text
+	 * @author David Grayson
+	 */
 	public void setNoteText(String strNote){
 		txtNoteField.syncEnabled(3);
 		txtNoteField.clear();
 		txtNoteField.set(strNote);
 	}
 
+	/**
+	 * clicks the create note element
+	 * @author David Grayson
+	 */
 	public void clickCreateNote(){
 		elmCreateNote.click();
 	}
 
+	/**
+	 * Gets the note text
+	 * @author David Grayson
+	 */
 	public String getNoteText(){
 		elmNoteText.syncVisible(3);
 		TestReporter.log("Note Text = [" + elmNoteText.getText() + "]");
 		return elmNoteText.getText();
 	}
 
-	public void testSetNote(){
-		setNoteText("test\ntest test");
-	}
-
+	/**
+	 * @author David Grayson
+	 * @return {@link Boolean} Returns <code>true</code> if the form is loaded, <code>false</code> otherwise.
+	 */
 	public boolean verifyFormIsLoaded() {
 		return PageLoaded.isElementLoaded(this.getClass(),driver,txtNoteField,5) &&
 				PageLoaded.isElementLoaded(this.getClass(),driver,elmCreateNote,5) &&

--- a/src/main/java/com/orasi/bluesource/ProjectNoteForm.java
+++ b/src/main/java/com/orasi/bluesource/ProjectNoteForm.java
@@ -2,6 +2,7 @@ package com.orasi.bluesource;
 
 import com.orasi.utils.TestReporter;
 import com.orasi.web.OrasiDriver;
+import com.orasi.web.PageLoaded;
 import com.orasi.web.webelements.Button;
 import com.orasi.web.webelements.Element;
 import com.orasi.web.webelements.Textbox;
@@ -10,7 +11,7 @@ import org.openqa.selenium.support.FindBy;
 
 /**
  * Page driver for the Create Notes Form on the project page
- * @author david.grayson
+ * @author David Grayson
  */
 public class ProjectNoteForm {
 	private OrasiDriver driver = null;
@@ -52,5 +53,11 @@ public class ProjectNoteForm {
 
 	public void testSetNote(){
 		setNoteText("test\ntest test");
+	}
+
+	public boolean verifyFormIsLoaded() {
+		return PageLoaded.isElementLoaded(this.getClass(),driver,txtNoteField,5) &&
+				PageLoaded.isElementLoaded(this.getClass(),driver,elmCreateNote,5) &&
+				PageLoaded.isElementLoaded(this.getClass(),driver,btnAddNote,5);
 	}
 }

--- a/src/test/java/com/bluesource/projects/PreserveNewLinesInProjectNotes.java
+++ b/src/test/java/com/bluesource/projects/PreserveNewLinesInProjectNotes.java
@@ -9,7 +9,7 @@ import com.orasi.web.WebBaseTest;
 import org.testng.ITestContext;
 import org.testng.annotations.*;
 
-public class Preserve_New_Lines_in_Project_Notes extends WebBaseTest {
+public class PreserveNewLinesInProjectNotes extends WebBaseTest {
 	@BeforeMethod
 	@Parameters({ "runLocation", "browserUnderTest", "browserVersion",
 			"operatingSystem", "environment" })

--- a/src/test/java/com/bluesource/projects/Preserve_New_Lines_in_Project_Notes.java
+++ b/src/test/java/com/bluesource/projects/Preserve_New_Lines_in_Project_Notes.java
@@ -1,0 +1,89 @@
+package com.bluesource.projects;
+
+import com.orasi.bluesource.Accounts;
+import com.orasi.bluesource.Header;
+import com.orasi.bluesource.LoginPage;
+import com.orasi.bluesource.ProjectNoteForm;
+import com.orasi.utils.TestReporter;
+import com.orasi.web.WebBaseTest;
+import org.testng.ITestContext;
+import org.testng.annotations.*;
+
+public class Preserve_New_Lines_in_Project_Notes extends WebBaseTest {
+	@BeforeMethod
+	@Parameters({ "runLocation", "browserUnderTest", "browserVersion",
+			"operatingSystem", "environment" })
+	public void setup(@Optional String runLocation, String browserUnderTest,
+					  String browserVersion, String operatingSystem, String environment) {
+		setApplicationUnderTest("BLUESOURCE");
+		setBrowserUnderTest(browserUnderTest);
+		setBrowserVersion(browserVersion);
+		setOperatingSystem(operatingSystem);
+		setRunLocation(runLocation);
+		setEnvironment(environment);
+		setThreadDriver(true);
+		testStart("Preserve New Lines in Project Notes");
+	}
+
+	@AfterMethod
+	public void close(ITestContext testResults){
+		endTest("TestAlert", testResults);
+	}
+
+	@Test
+	public void preserveNewLinesInProjectNotes(){
+		//Test Variables
+		String strAccount = "Account1";
+		String strProject = "Project1";
+		String strNote = "test\ntest test";
+		int numOfNotes = 0;
+
+		//Page Models
+		LoginPage loginPage = new LoginPage(getDriver());
+		Header header = new Header(getDriver());
+		Accounts accounts = new Accounts(getDriver());
+		ProjectNoteForm projectNoteForm = new ProjectNoteForm(getDriver());
+
+		TestReporter.logStep("Logging in as Admin");
+		loginPage.AdminLogin();
+
+		TestReporter.logStep("Navigating to Accounts page");
+		header.navigateAccounts();
+
+		TestReporter.logStep("Clicking " + strAccount + " account link");
+		accounts.clickAccountLink(strAccount);
+
+		TestReporter.logStep("Clicking " + strProject + " project link");
+		accounts.clickProjectLink(strProject);
+
+		TestReporter.logStep("Checking if the project already has notes");
+		if (accounts.verifyNoteCreated()){
+			numOfNotes = accounts.getNumberOfNotes();
+			TestReporter.logStep("The project has " + numOfNotes + " notes");
+		} else {
+			TestReporter.logStep("The project has no notes");
+		}
+
+		TestReporter.logStep("Clicking the Note button");
+		accounts.clickCreateNote();
+
+		TestReporter.logStep("Clicking the Add Note Button");
+		projectNoteForm.clickAddNote();
+
+		TestReporter.logStep("Setting note text");
+		projectNoteForm.setNoteText(strNote);
+
+		TestReporter.logStep("Clicking the create note button");
+		projectNoteForm.clickCreateNote();
+
+		TestReporter.assertTrue(accounts.verifyNoteCreated(),"Verifying note creation badge exists");
+
+		if (numOfNotes > 0)
+			TestReporter.assertTrue(numOfNotes < accounts.getNumberOfNotes(),"Verifying note creation badge incremented");
+
+		TestReporter.logStep("Clicking the Note button");
+		accounts.clickCreateNote();
+
+		TestReporter.assertEquals("test\ntest test",projectNoteForm.getNoteText(),"Verifying that the stored note is equal to the original");
+	}
+}

--- a/src/test/java/com/bluesource/projects/Preserve_New_Lines_in_Project_Notes.java
+++ b/src/test/java/com/bluesource/projects/Preserve_New_Lines_in_Project_Notes.java
@@ -44,17 +44,29 @@ public class Preserve_New_Lines_in_Project_Notes extends WebBaseTest {
 		Accounts accounts = new Accounts(getDriver());
 		ProjectNoteForm projectNoteForm = new ProjectNoteForm(getDriver());
 
+		TestReporter.assertTrue(loginPage.verifyPageIsLoaded(),"Verifying login page is loaded");
+
 		TestReporter.logStep("Logging in as Admin");
 		loginPage.AdminLogin();
 
 		TestReporter.logStep("Navigating to Accounts page");
 		header.navigateAccounts();
 
+		TestReporter.assertTrue(accounts.verifyAccountsPageIsLoaded(),"Verifying Accounts page is loaded");
+
+		TestReporter.assertTrue(accounts.verifyAccountLink(strAccount),"Verifying [" + strAccount + "] link");
+
 		TestReporter.logStep("Clicking " + strAccount + " account link");
 		accounts.clickAccountLink(strAccount);
 
+		TestReporter.assertTrue(accounts.verifyAccountPageIsLoaded(strAccount),"Verifying [" + strAccount + "] page is loaded");
+
+		TestReporter.assertTrue(accounts.verifyProjectLinkValid(strProject),"Verifying [" + strProject + "] link");
+
 		TestReporter.logStep("Clicking " + strProject + " project link");
 		accounts.clickProjectLink(strProject);
+
+		TestReporter.assertTrue(accounts.verifyProjectPageIsLoaded(strAccount,strProject),"Verifying [" + strProject + "] page is loaded");
 
 		TestReporter.logStep("Checking if the project already has notes");
 		if (accounts.verifyNoteCreated()){
@@ -66,6 +78,8 @@ public class Preserve_New_Lines_in_Project_Notes extends WebBaseTest {
 
 		TestReporter.logStep("Clicking the Note button");
 		accounts.clickCreateNote();
+
+		TestReporter.assertTrue(projectNoteForm.verifyFormIsLoaded(),"Verifying Create Note Form loaded");
 
 		TestReporter.logStep("Clicking the Add Note Button");
 		projectNoteForm.clickAddNote();
@@ -83,6 +97,8 @@ public class Preserve_New_Lines_in_Project_Notes extends WebBaseTest {
 
 		TestReporter.logStep("Clicking the Note button");
 		accounts.clickCreateNote();
+
+		TestReporter.assertTrue(projectNoteForm.verifyFormIsLoaded(),"Verifying Create Note Form loaded");
 
 		TestReporter.assertEquals("test\ntest test",projectNoteForm.getNoteText(),"Verifying that the stored note is equal to the original");
 	}

--- a/src/test/resources/sandbox.xml
+++ b/src/test/resources/sandbox.xml
@@ -13,7 +13,7 @@
 	
 	<test name="In Progress test" parallel="methods" thread-count="20">
 		<classes>
-			<class name="com.bluesource.accounts.CreateAccount" />
+			<class name="com.bluesource.projects.Preserve_New_Lines_in_Project_Notes" />
 		</classes>
 	</test>
 

--- a/src/test/resources/sandbox.xml
+++ b/src/test/resources/sandbox.xml
@@ -13,7 +13,7 @@
 	
 	<test name="In Progress test" parallel="methods" thread-count="20">
 		<classes>
-			<class name="com.bluesource.projects.Preserve_New_Lines_in_Project_Notes" />
+			<class name="com.bluesource.projects.PreserveNewLinesInProjectNotes" />
 		</classes>
 	</test>
 


### PR DESCRIPTION
This tests that new comments on projects are stored and displayed with their original structure intact and that the badge indicating the number of note associated with the project increments.

With access to (https://mustard.orasi.com) the test cases can be found here -
https://mustard.orasi.com/testcases/4665