### PR TITLE
Long Decimal on Burn Down Table - Edit Role Hours Test Issue 806 & 914

### DIFF
--- a/src/main/java/com/orasi/bluesource/AccountBurnDownDataReportForm.java
+++ b/src/main/java/com/orasi/bluesource/AccountBurnDownDataReportForm.java
@@ -1,0 +1,57 @@
+package com.orasi.bluesource;
+
+import com.orasi.web.OrasiDriver;
+import com.orasi.web.PageLoaded;
+import com.orasi.web.webelements.Element;
+import com.orasi.web.webelements.Listbox;
+import com.orasi.web.webelements.impl.internal.ElementFactory;
+import org.openqa.selenium.support.FindBy;
+
+public class AccountBurnDownDataReportForm {
+	private OrasiDriver driver = null;
+
+	/**Page Elements**/
+	@FindBy(xpath = "//div[contains(text(),'Select All')]") private Element elmSelectAll;
+	@FindBy(xpath = "//input[@name='commit']") private Element elmGenerateReport;
+	@FindBy(xpath = "//select[@id='account_select']") private Listbox lstAccountSelect;
+
+	/**
+	 * Constructor
+	 **/
+	public AccountBurnDownDataReportForm(OrasiDriver driver) {
+		this.driver = driver;
+		ElementFactory.initElements(driver, this);
+	}
+
+	/**Page Interactions**/
+
+	/**
+	 * @author David Grayson
+	 * @return {@link Boolean} Returns true if key elements of the form are loaded
+	 */
+	public boolean verifyFormLoaded(){
+		return PageLoaded.isElementLoaded(this.getClass(),driver,elmGenerateReport,5) &&
+				PageLoaded.isElementLoaded(this.getClass(),driver,lstAccountSelect,5) &&
+				PageLoaded.isElementLoaded(this.getClass(),driver,elmSelectAll,5);
+	}
+
+	public void selectAccount(String strAccount){
+		if (canInteract(lstAccountSelect)){
+			lstAccountSelect.select(strAccount);
+		}
+	}
+
+	public void clickGenerateReport(){
+		if (canInteract(elmGenerateReport))
+			elmGenerateReport.click();
+	}
+
+	/**
+	 * @author David Grayson
+	 * @param elm {@link Element} The element to check
+	 * @return {@link Boolean} Returns true if it can be interacted with, throws an error otherwise
+	 */
+	private boolean canInteract(Element elm){
+		return elm.syncEnabled(5) && elm.syncVisible(5);
+	}
+}

--- a/src/main/java/com/orasi/bluesource/Accounts.java
+++ b/src/main/java/com/orasi/bluesource/Accounts.java
@@ -46,6 +46,12 @@ public class Accounts {
 	@FindBy(css = "div.btn.btn-secondary.btn-xs.quick-nav") private Button btnQuickNav;
 	@FindBy(xpath = "//a[contains(@ng-bind, 'n + 1')]") private List<Button> btnPages;
 	@FindBy(xpath = "//*[@id=\"project-list\"]/div/div[1]/div") private Button btnCloseQuickNav;
+	@FindBy(xpath = "//span[@data-original-title='Edit Hours']/a") private Link lnkEditRoleHours;
+	@FindBy(xpath = "//h4[@class='panel-title' and contains(text(),'Project Info')]") private Element elmProjectInfoPanelHeader;
+	@FindBy(xpath = "//h4[@class='panel-title' and contains(text(),'Role Information')]") private Element elmRoleInfoPanelHeader;
+	@FindBy(xpath = "//th[contains(text(),'Document')]/../../..") private Webtable tblDocuments;
+	@FindBy(xpath = "//tr/th[contains(text(),'Rate')]/../../..") private Webtable tblRates;
+
 
 	/**Constructor**/
 	public Accounts(OrasiDriver driver){
@@ -54,6 +60,101 @@ public class Accounts {
 	}
 	
 	/**Page Interactions**/
+
+	/**
+	 * This method gets a Roles hours from the Roles page
+	 * @author David Grayson
+	 * @return {@link String} Returns the text of the most recent hours in the Rates panel
+	 */
+	public String getRoleHours(){
+		return tblRates.getCellData(1,4);
+	}
+
+	/**
+	 * This method will throw an error if no SOW document exists on Project page
+	 * @author David Grayson
+	 * @return {@link String} Returns the SOW document name
+	 */
+	public String getSOWDocumentName(){
+		PageLoaded.isDomComplete(driver);
+		int row = tblDocuments.getRowWithCellText("SOW");
+		return tblDocuments.getCell(row,1).getText();
+	}
+
+	/**
+	 * This method clicks the Edit Hours icon link (small clock) in the Rates panel on the Role page
+	 * @author David Grayson
+	 */
+	public void clickEditRoleHours(){
+		lnkEditRoleHours.syncEnabled(5);
+		lnkEditRoleHours.click();
+	}
+
+	/**
+	 * would use the {@link #verifyProjectLink(String)} but it doesn't do what it's name implies
+	 * @author David Grayson
+	 * @param project {@link String} name of Project
+	 * @return {@link Boolean} Returns <code>true</code> if the link is clickable within 5 seconds, <code>false</code> otherwise.
+	 */
+	public boolean verifyProjectLinkValid(String project){
+		return driver.findLink(By.linkText(project)).syncEnabled(5,false) &&
+				driver.findLink(By.linkText(project)).syncVisible(5,false);
+	}
+
+	/**
+	 * @author David Grayson
+	 * @param strRole {@link String} The name of the Role
+	 * @return {@link Boolean} Returns <code>true</code> if the link is enabled and visible, <code>false</code> otherwise.
+	 */
+	public boolean verifyRoleLink(String strRole) {
+		return driver.findLink(By.linkText(strRole)).syncEnabled(5,false) &&
+				driver.findLink(By.linkText(strRole)).syncVisible(5,false);
+	}
+
+	/**
+	 * @author David Grayson
+	 * @param strAccount {@link String} name of Roles parent account
+	 * @param strProject {@link String} name of Roles parent project
+	 * @param strRole {@link String} name of role
+	 * @return {@link Boolean} Returns <code>true</code> if the provided Roles page is loaded, <code>false</code> otherwise.
+	 */
+	public boolean verifyRolePageIsLoaded(String strAccount, String strProject, String strRole){
+		return PageLoaded.isElementLoaded(this.getClass(),driver,elmRoleInfoPanelHeader,5)
+				&& driver.findElement(By.xpath("//div[@class='breadcrumbs']")).getText()
+				.equals("Accounts - " + strAccount + " - " + strProject + " - " + strRole);
+	}
+
+	/**
+	 * @author David Grayson
+	 * @param strAccount {@link String} name of Projects parent account
+	 * @param strProject {@link String} name of project
+	 * @return {@link Boolean} Returns <code>true</code> if the provided Projects page is loaded, <code>false</code> otherwise.
+	 */
+	public boolean verifyProjectPageIsLoaded(String strAccount, String strProject){
+		return PageLoaded.isElementLoaded(this.getClass(),driver, elmProjectInfoPanelHeader,5)
+				&& driver.findElement(By.xpath("//div[@class='breadcrumbs']")).getText()
+				.equals("Accounts - " + strAccount + " - " + strProject);
+	}
+
+	/**
+	 * @author David Grayson
+	 * @param strAccount {@link String} name of Account
+	 * @return {@link Boolean} Returns <code>true</code> if the provided Accounts page is loaded, <code>false</code> otherwise.
+	 */
+	public boolean verifyAccountPageIsLoaded(String strAccount){
+		String xpath = "//div[@class='breadcrumbs']/a[contains(text(),'" + strAccount + "')]";
+		return PageLoaded.isElementLoaded(this.getClass(),driver,tblProjects,5)
+				&& driver.findLink(By.xpath(xpath)).syncVisible(5,false);
+	}
+
+	/**
+	 * @author David Grayson
+	 * @return {@link Boolean} Returns <code>true</code> if the Accounts table is loaded, <code>false</code> otherwise.
+	 */
+	public boolean verifyAccountsPageIsLoaded(){
+		return PageLoaded.isElementLoaded(this.getClass(),driver,tblAccounts,5);
+	}
+
 
 	/*
 	 * Click on accounts tab 

--- a/src/main/java/com/orasi/bluesource/EditRoleHoursForm.java
+++ b/src/main/java/com/orasi/bluesource/EditRoleHoursForm.java
@@ -1,0 +1,79 @@
+package com.orasi.bluesource;
+
+import com.orasi.web.OrasiDriver;
+import com.orasi.web.PageLoaded;
+import com.orasi.web.webelements.Button;
+import com.orasi.web.webelements.Element;
+import com.orasi.web.webelements.Listbox;
+import com.orasi.web.webelements.Textbox;
+import com.orasi.web.webelements.impl.internal.ElementFactory;
+import org.openqa.selenium.support.FindBy;
+
+public class EditRoleHoursForm {
+	private OrasiDriver driver = null;
+
+	/**Page Elements**/
+	@FindBy(xpath = "//input[@id='role_budget_hour_hours']") private Textbox txtHours;
+	@FindBy(xpath = "//select[@id='role_budget_hour_document_id']") private Listbox lstDocument;
+	@FindBy(xpath = "//textarea[@id='rate_comments']") private Textbox txtComments;
+	@FindBy(xpath = "//input[@value='Add Hours']") private Button btnAddHours;
+
+
+	/**
+	 * Constructor
+	 **/
+	public EditRoleHoursForm(OrasiDriver driver) {
+		this.driver = driver;
+		ElementFactory.initElements(driver, this);
+	}
+
+	/**Page Interactions**/
+
+	public void testSetHours(){
+		setHours(String.valueOf(Double.parseDouble(txtHours.getText().trim()) + 0.3513));
+	}
+
+	public void clickAddHours(){
+		if (canInteract(btnAddHours))
+			btnAddHours.click();
+	}
+
+	public void setComments(String comments){
+		if (canInteract(txtComments)){
+			txtComments.clear();
+			txtComments.sendKeys(comments);
+		}
+	}
+
+	public void setDocument(String documentName){
+		if (canInteract(lstDocument))
+			lstDocument.select(documentName);
+	}
+
+	public void setHours(String hours){
+		if (canInteract(txtHours)){
+			txtHours.clear();
+			txtHours.sendKeys(hours);
+		}
+	}
+
+	/**
+	 * @author David Grayson
+	 * @return {@link Boolean} Returns true if key elements of the form have loaded
+	 */
+	public boolean verifyFormLoaded(){
+		return PageLoaded.isElementLoaded(this.getClass(),driver,txtHours,5) &&
+				PageLoaded.isElementLoaded(this.getClass(),driver,lstDocument,5) &&
+				PageLoaded.isElementLoaded(this.getClass(),driver,txtComments,5);
+	}
+
+	/**
+	 * This method provides standard checks that an element can be interacted with
+	 * @author David Grayson
+	 * @param elm {@link Element} Element to check
+	 * @return {@link Boolean} Returns <code>true</code> if the element is enabled and visible, <code>false</code> otherwise
+	 */
+	private boolean canInteract(Element elm){
+		return elm.syncEnabled(5) && elm.syncVisible(5);
+	}
+}

--- a/src/main/java/com/orasi/bluesource/Header.java
+++ b/src/main/java/com/orasi/bluesource/Header.java
@@ -28,6 +28,16 @@ public class Header {
 	/**Page Interactions**/
 
 	/**
+	 * This method navigates to the Reporting login page
+	 * @author David Grayson
+	 */
+	public void navigateReporting(){
+		MessageCenter messageCenter = new MessageCenter(driver);
+		messageCenter.closeMessageCenter();
+		driver.get("http://10.238.243.127:8080/reporting/login");
+	}
+
+	/**
 	 * This method navigates to Accounts page
 	 * @author Paul
 	 */

--- a/src/main/java/com/orasi/bluesource/Report.java
+++ b/src/main/java/com/orasi/bluesource/Report.java
@@ -1,0 +1,55 @@
+package com.orasi.bluesource;
+
+import com.orasi.utils.TestReporter;
+import com.orasi.web.OrasiDriver;
+import com.orasi.web.PageLoaded;
+import com.orasi.web.webelements.Element;
+import com.orasi.web.webelements.Webtable;
+import com.orasi.web.webelements.impl.internal.ElementFactory;
+import org.openqa.selenium.support.FindBy;
+
+public class Report {
+	private OrasiDriver driver = null;
+
+	/**Page Elements**/
+	@FindBy(xpath = "//h3[@class='report-title']") private Element elmReportTitle;
+	@FindBy(xpath = "//table") private Webtable tblReport;
+
+
+	/**
+	 * Constructor
+	 **/
+	public Report(OrasiDriver driver) {
+		this.driver = driver;
+		ElementFactory.initElements(driver, this);
+	}
+
+	/**Page Interactions**/
+
+	/**
+	 * @author David Grayson
+	 * @return {@link Boolean} Returns <code>true</code> if the report is loaded, <code>false</code> otherwise.
+	 */
+	public boolean verifyReportIsLoaded(){
+		return PageLoaded.isElementLoaded(this.getClass(),driver,elmReportTitle,5) &&
+				PageLoaded.isElementLoaded(this.getClass(),driver,tblReport,5);
+	}
+
+	/**
+	 * @author David Grayson
+	 * @return {@link Boolean} Returns true if a report has a field with more than 2 decimals
+	 */
+	public boolean doesReportHaveLongDecimals(){
+		for (int i = 1; i <= tblReport.getRowCount(); i++){
+			for (int x = 1; x <= 7; x++){
+				TestReporter.log("Checking cell "+i+","+x);
+				if (tblReport.getCellData(i,x).contains(".")){
+					String[] split = tblReport.getCellData(i,x).split("[.]");
+					if (split[1].length()>2)
+						return true;
+				}
+			}
+		}
+		return false;
+	}
+}

--- a/src/main/java/com/orasi/bluesource/ReportingNavBar.java
+++ b/src/main/java/com/orasi/bluesource/ReportingNavBar.java
@@ -1,0 +1,63 @@
+package com.orasi.bluesource;
+
+import com.orasi.web.OrasiDriver;
+import com.orasi.web.webelements.Element;
+import com.orasi.web.webelements.Link;
+import com.orasi.web.webelements.impl.internal.ElementFactory;
+import org.openqa.selenium.support.FindBy;
+
+public class ReportingNavBar {
+	private OrasiDriver driver = null;
+
+	/**Page Elements**/
+	@FindBy(xpath = "//h1[text()='Welcome']") private Element elmWelcome;
+	@FindBy(xpath = "//span[contains(text(),'Account Reports')]/..") private Link lnkAccountReportsDropdown;
+	@FindBy(xpath = "//span[contains(text(),'Account Reports')]/../..//a[contains(text(),'Burn Down Data')]") private Link lnkAccountReportsBurnDownData;
+
+	/**
+	 * Constructor
+	 **/
+	public ReportingNavBar(OrasiDriver driver) {
+		this.driver = driver;
+		ElementFactory.initElements(driver, this);
+	}
+
+	/**Page Interactions**/
+
+	/**
+	 * @author David Grayson
+	 * @return {@link Boolean} Returns <code>true</code> if on the Reporting Home page.
+	 */
+	public boolean verifyHomePageIsDisplayed(){
+		return elmWelcome.syncVisible(5,false);
+	}
+
+	/**
+	 * This method clicks Burn Down Data link under the Account Reports drop down menu
+	 * @author David Grayson
+	 */
+	public void clickAccountBurnDownData(){
+		if (canInteract(lnkAccountReportsBurnDownData))
+			lnkAccountReportsBurnDownData.click();
+	}
+
+	/**
+	 * This method expands the Projects Reports drop down
+	 * @author David Grayson
+	 */
+	public void clickAccountReports(){
+		if (canInteract(lnkAccountReportsDropdown))
+			lnkAccountReportsDropdown.click();
+	}
+
+	/**
+	 * This method provides standard checks that an element can be interacted with
+	 * @author David Grayson
+	 * @param elm {@link Element} Element to check
+	 * @return {@link Boolean} Returns <code>true</code> if the element is enabled and visible, <code>false</code> otherwise
+	 */
+	private boolean canInteract(Element elm){
+		return elm.syncEnabled(5) && elm.syncVisible(5);
+	}
+
+}

--- a/src/test/java/com/bluesource/reports/LongDecimalsOnBurnDownTableEditRoleHours.java
+++ b/src/test/java/com/bluesource/reports/LongDecimalsOnBurnDownTableEditRoleHours.java
@@ -1,0 +1,134 @@
+package com.bluesource.reports;
+
+import com.orasi.bluesource.*;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+import org.testng.ITestContext;
+
+import com.orasi.utils.TestReporter;
+import com.orasi.web.WebBaseTest;
+
+public class LongDecimalsOnBurnDownTableEditRoleHours extends WebBaseTest {
+	@BeforeMethod
+	@Parameters({"runLocation", "browserUnderTest", "browserVersion",
+			"operatingSystem", "environment"})
+	public void setup(@Optional String runLocation, String browserUnderTest,
+					  String browserVersion, String operatingSystem, String environment) {
+		setApplicationUnderTest("BLUESOURCE");
+		setBrowserUnderTest(browserUnderTest);
+		setBrowserVersion(browserVersion);
+		setOperatingSystem(operatingSystem);
+		setRunLocation(runLocation);
+		setEnvironment(environment);
+		setThreadDriver(true);
+		testStart("");
+	}
+
+	@AfterMethod
+	public void close(ITestContext testResults) {
+		endTest("TestAlert", testResults);
+	}
+
+	@Test
+	public void longDecimalsOnBurnDownTableEditRoleHours() {
+		//Test Variables
+		String strAccount = "Account1";
+		String strProject = "Project2";
+		String strRole = "Role3";
+		String comments = "test";
+		String docName, oldHours;
+
+		//Page Models
+		LoginPage loginPage = new LoginPage(getDriver());
+		Header header = new Header(getDriver());
+		Accounts accounts = new Accounts(getDriver());
+		EditRoleHoursForm editRoleHoursForm = new EditRoleHoursForm(getDriver());
+		AccountBurnDownDataReportForm burnDownDataReportForm = new AccountBurnDownDataReportForm(getDriver());
+		Report report = new Report(getDriver());
+		ReportingNavBar reportingNavBar = new ReportingNavBar(getDriver());
+
+		TestReporter.assertTrue(loginPage.verifyPageIsLoaded(),"Verifying BlueSource login page is loaded");
+
+		TestReporter.logStep("Logging in as Admin");
+		loginPage.AdminLogin();
+
+		TestReporter.logStep("Navigating to Accounts");
+		header.navigateAccounts();
+
+		TestReporter.assertTrue(accounts.verifyAccountsPageIsLoaded(), "Verifying Accounts page is loaded");
+		TestReporter.assertTrue(accounts.verifyAccountLink(strAccount),"Verifying Account ["+strAccount+"] link");
+
+		TestReporter.logStep("Clicking Account ["+strAccount+"] link");
+		accounts.clickAccountLink(strAccount);
+
+		TestReporter.assertTrue(accounts.verifyAccountPageIsLoaded(strAccount),"Verifying Account ["+strAccount+"] page is loaded");
+		TestReporter.assertTrue(accounts.verifyProjectLinkValid(strProject),"Verifying Project ["+strProject+"] link");
+
+		TestReporter.logStep("Clicking Project "+strProject+" link");
+		accounts.clickProjectLink(strProject);
+
+		TestReporter.logStep("Getting SOW document name");
+		docName = accounts.getSOWDocumentName();
+
+		TestReporter.assertTrue(accounts.verifyProjectPageIsLoaded(strAccount,strProject),"Verifying Project ["+strProject+"] page is loaded");
+		TestReporter.assertTrue(accounts.verifyRoleLink(strRole),"Verifying Role ["+strRole+"] link");
+
+		TestReporter.logStep("Clicking Role ["+strRole+"] link");
+		accounts.clickRoleLink(strRole);
+
+		TestReporter.assertTrue(accounts.verifyRolePageIsLoaded(strAccount,strProject,strRole),"Verifying Role ["+strRole+"] page is loaded");
+
+		TestReporter.logStep("Getting roles hours");
+		oldHours = accounts.getRoleHours();
+
+		TestReporter.logStep("Clicking Edit Hours");
+		accounts.clickEditRoleHours();
+
+		TestReporter.assertTrue(editRoleHoursForm.verifyFormLoaded(),"Verifying Edit Role Hours form loaded");
+
+		TestReporter.logStep("Setting comments");
+		editRoleHoursForm.setComments(comments);
+
+		TestReporter.logStep("Setting hours");
+		editRoleHoursForm.testSetHours();
+
+		TestReporter.logStep("Selecting SOW Document");
+		editRoleHoursForm.setDocument("SOW - "+docName.trim());
+
+		TestReporter.logStep("Clicking Add Hours");
+		editRoleHoursForm.clickAddHours();
+
+		TestReporter.assertNotEquals(oldHours,accounts.getRoleHours(),"Verifying Role hours were changed");
+
+		TestReporter.logStep("Navigating to BlueSource Reporting login page");
+		header.navigateReporting();
+
+		TestReporter.assertTrue(loginPage.verifyPageIsLoaded(),"Verifying BlueSource Reporting login page is loaded");
+
+		TestReporter.logStep("Logging in as Admin");
+		loginPage.AdminLogin();
+
+		TestReporter.assertTrue(reportingNavBar.verifyHomePageIsDisplayed(),"Verifying Reporting home page is displayed");
+
+		TestReporter.logStep("Clicking Account Reports");
+		reportingNavBar.clickAccountReports();
+
+		TestReporter.logStep("Clicking Burn Down Data");
+		reportingNavBar.clickAccountBurnDownData();
+
+		TestReporter.assertTrue(burnDownDataReportForm.verifyFormLoaded(),"verifying form loaded");
+
+		TestReporter.logStep("Selecting Account ["+strAccount+"]");
+		burnDownDataReportForm.selectAccount(strAccount);
+
+		TestReporter.logStep("Clicking Generate Report");
+		burnDownDataReportForm.clickGenerateReport();
+
+		TestReporter.assertTrue(report.verifyReportIsLoaded(),"Verifying report loaded");
+
+		TestReporter.assertFalse(report.doesReportHaveLongDecimals(),"Verifying report doesn't have any long decimals");
+	}
+}


### PR DESCRIPTION
This tests that editing a roles hours to include a decimal (e.g. 131.985) doesn't make the burn down report display long decimals.

With access to (https://mustard.orasi.com) the test cases can be found here -
https://mustard.orasi.com/testcases/4704